### PR TITLE
Phase 7: Reconnection — context, plans, and Outcome<T> design

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -123,7 +123,9 @@ Decimal phases appear between their surrounding integers in numeric order.
   2. An authentication failure during reconnection is propagated immediately to the caller — the client does not retry on `AuthFailed` errors
   3. After a reconnect, the caller receives an explicit signal that session state (including any pending DELE marks) has been lost — the API does not silently discard this information
   4. Consecutive reconnection attempts use increasing wait intervals with random jitter — two concurrent clients do not produce synchronized retry storms
-**Plans**: TBD
+**Plans:** 2 plans
+- [ ] 07-01-PLAN.md — backon dependency, SessionReset ZST, ReconnectingClientBuilder, ReconnectingClient struct + retry infrastructure (RECON-01, RECON-02, RECON-04)
+- [ ] 07-02-PLAN.md — All delegating command methods, lib.rs re-exports, tests covering all four RECON requirements (RECON-01, RECON-02, RECON-03, RECON-04)
 
 ### Phase 8: Connection Pooling
 **Goal**: Callers can manage multiple POP3 accounts concurrently using a pool that enforces the RFC 1939 exclusive-lock constraint at the type level and in documentation

--- a/.planning/phases/07-reconnection/07-01-PLAN.md
+++ b/.planning/phases/07-reconnection/07-01-PLAN.md
@@ -11,11 +11,11 @@ autonomous: true
 must_haves:
   - backon = "1.6" is present in Cargo.toml [dependencies]
   - src/reconnect.rs exists and compiles without errors
-  - SessionReset is a pub #[must_use] ZST with Debug + Clone + Copy + PartialEq + Eq
+  - Outcome<T> is a pub enum with Fresh(T) and Reconnected(T) variants, with into_inner() -> T and is_reconnected() -> bool convenience methods
   - ReconnectingClientBuilder struct is pub with fields for max_retries, initial_delay, max_delay, jitter, and on_reconnect callback
   - ReconnectingClient struct is pub and holds builder: Pop3ClientBuilder, username: String, password: String, client: Pop3Client
   - connect_and_auth free function creates a fresh Pop3Client via builder.connect().await and calls client.login()
-  - is_retryable returns true for Io, ConnectionClosed, Timeout only
+  - is_retryable returns true for Io, ConnectionClosed, Timeout, SysTemp
   - ReconnectingClientBuilder::connect() performs initial connection via connect_and_auth with backon retry loop using ExponentialBuilder with_jitter
   - cargo build succeeds with no warnings on rustls-tls feature
 requirements:
@@ -26,7 +26,7 @@ requirements:
 
 ## Objective
 
-Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `SessionReset` ZST, `ReconnectingClientBuilder`, and `ReconnectingClient` struct including the internal retry infrastructure (`connect_and_auth`, `is_retryable`, `do_reconnect`). This plan establishes the foundation types and reconnection machinery consumed by Plan 02.
+Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Outcome<T>` enum, `ReconnectingClientBuilder`, and `ReconnectingClient` struct including the internal retry infrastructure (`connect_and_auth`, `is_retryable`, `do_reconnect`). This plan establishes the foundation types and reconnection machinery consumed by Plan 02.
 
 ## Context
 
@@ -45,7 +45,10 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
 - Optional `.on_reconnect(|attempt, error|)` callback — informational only, `FnMut(u32, &Pop3Error)`, not stored as `Box<dyn Fn>` (use `Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>`)
 - Initial connect also goes through the retry loop
 - `backon` 1.6 is the unconditional retry crate (already in STATE.md decisions)
-- Retryable errors: `Pop3Error::Io(_)`, `Pop3Error::ConnectionClosed`, `Pop3Error::Timeout` only
+- Wrapper return type: every fallible method returns `Result<Outcome<T>>` where `Outcome` is an enum with `Fresh(T)` and `Reconnected(T)` variants
+- Compile-time enforcement — callers must handle the reconnection case; they cannot ignore it
+- Convenience methods: `into_inner() -> T` and `is_reconnected() -> bool`
+- Retryable errors: `Pop3Error::Io(_)`, `Pop3Error::ConnectionClosed`, `Pop3Error::Timeout`, `Pop3Error::SysTemp(_)`
 - `Pop3Error::AuthFailed` MUST NEVER be retried — account lockout risk
 
 **From RESEARCH.md:**
@@ -62,13 +65,13 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   <files>Cargo.toml, src/reconnect.rs</files>
   <behavior>
     - backon = "1.6" added to [dependencies] in Cargo.toml (unconditional, no feature flag)
-    - SessionReset is a pub unit struct, zero-sized, with: #[must_use = "check whether a session reset occurred to detect discarded DELE marks"], #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    - Outcome<T> is a pub enum with two variants: Fresh(T) and Reconnected(T). Derives: #[derive(Debug, Clone, PartialEq, Eq)] (conditional on T bounds). Convenience methods on Outcome<T>: into_inner(self) -> T (returns the inner value regardless of variant), is_reconnected(&self) -> bool (returns true iff Reconnected variant)
     - ReconnectingClientBuilder is a pub struct with fields: builder: Pop3ClientBuilder, max_retries: usize (default 3), initial_delay: Duration (default 1s), max_delay: Duration (default 30s), jitter: bool (default true), on_reconnect: Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>
     - ReconnectingClientBuilder::new(builder: Pop3ClientBuilder) is the constructor, sets all defaults
     - Builder methods (consuming self): .max_retries(n: usize) -> Self, .initial_delay(d: Duration) -> Self, .max_delay(d: Duration) -> Self, .jitter(enabled: bool) -> Self, .on_reconnect(f: impl FnMut(u32, &Pop3Error) + Send + 'static) -> Self
     - ReconnectingClient is a pub struct with fields: builder: Pop3ClientBuilder, username: String, password: String, client: Pop3Client, max_retries: usize, initial_delay: Duration, max_delay: Duration, jitter: bool, on_reconnect: Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>
     - connect_and_auth(builder: &Pop3ClientBuilder, username: &str, password: &str) -> crate::Result<Pop3Client> is a module-level async fn (not pub): calls builder.clone().connect().await? then client.login(username, password).await?, returns the client
-    - is_retryable(e: &Pop3Error) -> bool is a module-level fn (not pub): returns matches!(e, Pop3Error::Io(_) | Pop3Error::ConnectionClosed | Pop3Error::Timeout)
+    - is_retryable(e: &Pop3Error) -> bool is a module-level fn (not pub): returns matches!(e, Pop3Error::Io(_) | Pop3Error::ConnectionClosed | Pop3Error::Timeout | Pop3Error::SysTemp(_))
     - ReconnectingClientBuilder::connect(mut self) -> crate::Result<ReconnectingClient> is pub async: runs the initial connect_and_auth inside a backon retry loop; builds ExponentialBuilder with self.jitter/self.max_retries/self.initial_delay/self.max_delay; if self.on_reconnect is Some, use .notify() on the retry chain with attempt counter tracking; returns Ok(ReconnectingClient { builder: self.builder, username: self.username, ... })
     - The on_reconnect callback signature in .notify() must adapt: backon's .notify(|err, dur|) gives error and duration, but the user callback wants (attempt, &Pop3Error); track a local mut attempt counter in a closure capturing &mut attempt
     - ReconnectingClient has a pub(self) async fn do_reconnect(&mut self) -> crate::Result<()>: rebuilds the inner client using connect_and_auth inside the same backon retry loop with the stored configuration
@@ -85,21 +88,25 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   //!
   //! [`ReconnectingClient`] wraps a [`Pop3Client`] and transparently reconnects on I/O
   //! errors using exponential backoff with jitter (via the `backon` crate). Every method
-  //! returns `Option<SessionReset>` alongside the result so callers know whether pending
-  //! DELE marks were discarded.
+  //! returns `Outcome<T>` so callers know whether pending DELE marks were discarded.
   //!
   //! # Session-State Loss
   //!
   //! POP3 DELE marks are committed only on `QUIT`. A reconnect starts a fresh session,
   //! silently discarding all pending DELEs. To prevent data-loss bugs, every fallible
-  //! method on `ReconnectingClient` returns `Option<SessionReset>`:
-  //! - `None` — the existing connection was used; no state was lost
-  //! - `Some(SessionReset)` — a reconnect occurred; all pending DELE marks are gone
+  //! method on `ReconnectingClient` returns `Result<Outcome<T>>`:
+  //! - `Fresh(T)` — the existing connection was used; no state was lost
+  //! - `Reconnected(T)` — a reconnect occurred; all pending DELE marks are gone
+  //!
+  //! Callers must handle both variants. Use `outcome.into_inner()` to extract the value
+  //! when the reconnection signal is intentionally ignored, or `outcome.is_reconnected()`
+  //! to branch on it.
   //!
   //! # Error Classification
   //!
   //! Only transient connection errors trigger a reconnect: [`Pop3Error::Io`],
-  //! [`Pop3Error::ConnectionClosed`], and [`Pop3Error::Timeout`].
+  //! [`Pop3Error::ConnectionClosed`], [`Pop3Error::Timeout`], and [`Pop3Error::SysTemp`]
+  //! (explicitly transient per RFC 3206).
   //!
   //! [`Pop3Error::AuthFailed`] is **never** retried — retrying wrong credentials
   //! risks account lockout on servers with brute-force protection.
@@ -107,7 +114,7 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   //! # Usage
   //!
   //! ```no_run
-  //! use pop3::{Pop3ClientBuilder, ReconnectingClientBuilder, SessionReset};
+  //! use pop3::{Pop3ClientBuilder, ReconnectingClientBuilder, Outcome};
   //!
   //! #[tokio::main]
   //! async fn main() -> pop3::Result<()> {
@@ -118,10 +125,11 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   //!     .connect("user@example.com", "app-password")
   //!     .await?;
   //!
-  //!     let (stat, reset) = client.stat().await?;
-  //!     if reset.is_some() {
+  //!     let outcome = client.stat().await?;
+  //!     if outcome.is_reconnected() {
   //!         eprintln!("Session was reset — DELE marks discarded");
   //!     }
+  //!     let stat = outcome.into_inner();
   //!     client.quit().await?;
   //!     Ok(())
   //! }
@@ -131,7 +139,7 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   use backon::{ExponentialBuilder, Retryable};
   use crate::{Pop3Client, Pop3ClientBuilder, Pop3Error, Result};
 
-  // SessionReset, ReconnectingClientBuilder, ReconnectingClient as described above.
+  // Outcome<T>, ReconnectingClientBuilder, ReconnectingClient as described above.
   // connect_and_auth, is_retryable as module-level fns.
   // ReconnectingClientBuilder::connect(mut self, username, password) — take username/password as Into<String> parameters (note: CONTEXT.md says credentials are stored at construction time; connect() is the terminal method that receives them).
   ```
@@ -172,34 +180,41 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
   <done>
     - Cargo.toml has backon = "1.6" in [dependencies]
     - src/reconnect.rs compiles with cargo build (no errors)
-    - SessionReset, ReconnectingClientBuilder, ReconnectingClient are defined as described
+    - Outcome<T> enum is defined with Fresh(T) and Reconnected(T) variants and into_inner()/is_reconnected() methods
+    - ReconnectingClientBuilder, ReconnectingClient are defined as described
     - connect_and_auth and is_retryable are implemented
+    - is_retryable covers Io, ConnectionClosed, Timeout, SysTemp
     - ReconnectingClientBuilder::connect() performs the initial backon retry loop
     - ReconnectingClient::do_reconnect() is implemented for use by Plan 02 method wrappers
   </done>
 </task>
 
 <task type="auto" tdd="true">
-  <name>Task 2: Unit tests for retry infrastructure (is_retryable, connect_and_auth, ReconnectingClientBuilder)</name>
+  <name>Task 2: Unit tests for retry infrastructure (is_retryable, Outcome<T>, ReconnectingClientBuilder)</name>
   <files>src/reconnect.rs</files>
   <behavior>
     - test: is_retryable_io_error — Pop3Error::Io(io::Error::new(io::ErrorKind::ConnectionReset, "reset")) returns true
     - test: is_retryable_connection_closed — Pop3Error::ConnectionClosed returns true
     - test: is_retryable_timeout — Pop3Error::Timeout returns true
+    - test: is_retryable_sys_temp — Pop3Error::SysTemp("transient".into()) returns true (explicitly transient per RFC 3206)
     - test: is_retryable_auth_failed — Pop3Error::AuthFailed("bad pass".into()) returns false
     - test: is_retryable_server_error — Pop3Error::ServerError("no msg".into()) returns false
     - test: is_retryable_parse_error — Pop3Error::Parse("bad resp".into()) returns false
     - test: is_retryable_invalid_input — Pop3Error::InvalidInput returns false
     - test: is_retryable_tls — Pop3Error::Tls("cert error".into()) returns false
     - test: is_retryable_mailbox_in_use — Pop3Error::MailboxInUse("in use".into()) returns false
-    - test: session_reset_is_zst — assert_eq!(std::mem::size_of::<SessionReset>(), 0)
-    - test: session_reset_derives — SessionReset implements Debug, Clone, Copy, PartialEq, Eq
+    - test: outcome_fresh_into_inner — Outcome::Fresh(42u32).into_inner() == 42
+    - test: outcome_reconnected_into_inner — Outcome::Reconnected(42u32).into_inner() == 42
+    - test: outcome_fresh_is_reconnected — Outcome::<u32>::Fresh(0).is_reconnected() == false
+    - test: outcome_reconnected_is_reconnected — Outcome::<u32>::Reconnected(0).is_reconnected() == true
     - test: reconnecting_builder_defaults — ReconnectingClientBuilder::new(builder).max_retries field is 3, initial_delay is 1s, max_delay is 30s, jitter is true
   </behavior>
   <action>
   Add a `#[cfg(test)]` module at the bottom of src/reconnect.rs. All tests are inline unit tests (consistent with project patterns — no separate test files).
 
   For is_retryable tests: call the module-level `is_retryable` fn directly (it is visible to the test module within the same file).
+
+  For Outcome tests: construct Outcome::Fresh and Outcome::Reconnected directly and call into_inner() / is_reconnected().
 
   For ReconnectingClientBuilder defaults test: construct a dummy builder. Pop3ClientBuilder::new("localhost") is sufficient — no actual connection is made. Check the fields via direct field access (fields are pub(self) or you can access them from within the module).
 
@@ -213,7 +228,7 @@ Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `Sessio
     <automated>cargo test reconnect --features rustls-tls 2>&1 | tail -20</automated>
   </verify>
   <done>
-    - All 12 unit tests for is_retryable and SessionReset pass
+    - All 15 unit tests for is_retryable and Outcome pass
     - cargo test reconnect shows 0 failures
     - cargo clippy -- -D warnings passes with no new warnings from reconnect.rs
   </done>
@@ -234,11 +249,11 @@ All must pass with zero errors and zero warnings before Plan 02 begins.
 
 1. `src/reconnect.rs` compiles clean with no warnings
 2. `backon = "1.6"` is in `Cargo.toml` (no feature flag)
-3. `SessionReset` is a `#[must_use]` ZST with Debug/Clone/Copy/PartialEq/Eq
-4. `is_retryable` correctly returns true only for Io, ConnectionClosed, Timeout
+3. `Outcome<T>` is a pub enum with `Fresh(T)` and `Reconnected(T)` variants and `into_inner()` / `is_reconnected()` convenience methods
+4. `is_retryable` correctly returns true for `Io`, `ConnectionClosed`, `Timeout`, `SysTemp` — and false for all others
 5. `ReconnectingClientBuilder::connect()` wraps initial connection in a backon retry loop with `.with_jitter()` active
 6. `ReconnectingClient::do_reconnect()` rebuilds `self.client` using the same retry machinery
-7. All 12 unit tests in the `#[cfg(test)]` module pass
+7. All 15 unit tests in the `#[cfg(test)]` module pass
 
 ## Output
 

--- a/.planning/phases/07-reconnection/07-01-PLAN.md
+++ b/.planning/phases/07-reconnection/07-01-PLAN.md
@@ -1,0 +1,245 @@
+---
+phase: 07-reconnection
+plan: "01"
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - Cargo.toml
+  - src/reconnect.rs
+autonomous: true
+must_haves:
+  - backon = "1.6" is present in Cargo.toml [dependencies]
+  - src/reconnect.rs exists and compiles without errors
+  - SessionReset is a pub #[must_use] ZST with Debug + Clone + Copy + PartialEq + Eq
+  - ReconnectingClientBuilder struct is pub with fields for max_retries, initial_delay, max_delay, jitter, and on_reconnect callback
+  - ReconnectingClient struct is pub and holds builder: Pop3ClientBuilder, username: String, password: String, client: Pop3Client
+  - connect_and_auth free function creates a fresh Pop3Client via builder.connect().await and calls client.login()
+  - is_retryable returns true for Io, ConnectionClosed, Timeout only
+  - ReconnectingClientBuilder::connect() performs initial connection via connect_and_auth with backon retry loop using ExponentialBuilder with_jitter
+  - cargo build succeeds with no warnings on rustls-tls feature
+requirements:
+  - RECON-01
+  - RECON-02
+  - RECON-04
+---
+
+## Objective
+
+Add `backon = "1.6"` to `Cargo.toml`, create `src/reconnect.rs` with the `SessionReset` ZST, `ReconnectingClientBuilder`, and `ReconnectingClient` struct including the internal retry infrastructure (`connect_and_auth`, `is_retryable`, `do_reconnect`). This plan establishes the foundation types and reconnection machinery consumed by Plan 02.
+
+## Context
+
+@.planning/phases/07-reconnection/07-CONTEXT.md
+@.planning/phases/07-reconnection/07-RESEARCH.md
+@src/error.rs
+@src/builder.rs
+@src/client.rs
+@Cargo.toml
+@src/lib.rs
+
+**Key decisions from CONTEXT.md (locked):**
+- Decorator pattern: `ReconnectingClient` wraps `Pop3ClientBuilder` + stored credentials, NOT `Pop3Client` directly
+- `ReconnectingClientBuilder` separate from `Pop3ClientBuilder` — takes a `Pop3ClientBuilder` as input
+- Configurable: `.max_retries(n)` (default 3), `.initial_delay(dur)` (default 1s), `.max_delay(dur)` (default 30s), `.jitter(bool)` (default true)
+- Optional `.on_reconnect(|attempt, error|)` callback — informational only, `FnMut(u32, &Pop3Error)`, not stored as `Box<dyn Fn>` (use `Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>`)
+- Initial connect also goes through the retry loop
+- `backon` 1.6 is the unconditional retry crate (already in STATE.md decisions)
+- Retryable errors: `Pop3Error::Io(_)`, `Pop3Error::ConnectionClosed`, `Pop3Error::Timeout` only
+- `Pop3Error::AuthFailed` MUST NEVER be retried — account lockout risk
+
+**From RESEARCH.md:**
+- `ExponentialBuilder::default()` has jitter=false, max_times=Some(3), min=1s, max=60s — override all for production use
+- `.with_jitter()` must be called explicitly (jitter is off by default)
+- `.sleep(tokio::time::sleep)` is required for async contexts
+- backon `tokio-sleep` is enabled by default so no feature flag needed in Cargo.toml
+- Closure for backon must be `FnMut() -> Future` — extract `&builder`, `username.as_str()`, `password.as_str()` into locals before the closure to avoid borrow conflicts
+
+## Tasks
+
+<task type="auto">
+  <name>Task 1: Add backon dependency and create reconnect.rs skeleton</name>
+  <files>Cargo.toml, src/reconnect.rs</files>
+  <behavior>
+    - backon = "1.6" added to [dependencies] in Cargo.toml (unconditional, no feature flag)
+    - SessionReset is a pub unit struct, zero-sized, with: #[must_use = "check whether a session reset occurred to detect discarded DELE marks"], #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    - ReconnectingClientBuilder is a pub struct with fields: builder: Pop3ClientBuilder, max_retries: usize (default 3), initial_delay: Duration (default 1s), max_delay: Duration (default 30s), jitter: bool (default true), on_reconnect: Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>
+    - ReconnectingClientBuilder::new(builder: Pop3ClientBuilder) is the constructor, sets all defaults
+    - Builder methods (consuming self): .max_retries(n: usize) -> Self, .initial_delay(d: Duration) -> Self, .max_delay(d: Duration) -> Self, .jitter(enabled: bool) -> Self, .on_reconnect(f: impl FnMut(u32, &Pop3Error) + Send + 'static) -> Self
+    - ReconnectingClient is a pub struct with fields: builder: Pop3ClientBuilder, username: String, password: String, client: Pop3Client, max_retries: usize, initial_delay: Duration, max_delay: Duration, jitter: bool, on_reconnect: Option<Box<dyn FnMut(u32, &Pop3Error) + Send>>
+    - connect_and_auth(builder: &Pop3ClientBuilder, username: &str, password: &str) -> crate::Result<Pop3Client> is a module-level async fn (not pub): calls builder.clone().connect().await? then client.login(username, password).await?, returns the client
+    - is_retryable(e: &Pop3Error) -> bool is a module-level fn (not pub): returns matches!(e, Pop3Error::Io(_) | Pop3Error::ConnectionClosed | Pop3Error::Timeout)
+    - ReconnectingClientBuilder::connect(mut self) -> crate::Result<ReconnectingClient> is pub async: runs the initial connect_and_auth inside a backon retry loop; builds ExponentialBuilder with self.jitter/self.max_retries/self.initial_delay/self.max_delay; if self.on_reconnect is Some, use .notify() on the retry chain with attempt counter tracking; returns Ok(ReconnectingClient { builder: self.builder, username: self.username, ... })
+    - The on_reconnect callback signature in .notify() must adapt: backon's .notify(|err, dur|) gives error and duration, but the user callback wants (attempt, &Pop3Error); track a local mut attempt counter in a closure capturing &mut attempt
+    - ReconnectingClient has a pub(self) async fn do_reconnect(&mut self) -> crate::Result<()>: rebuilds the inner client using connect_and_auth inside the same backon retry loop with the stored configuration
+  </behavior>
+  <action>
+  1. Open Cargo.toml. In [dependencies], add a line: `backon = "1.6"`. Place it after `md5`.
+
+  2. Create src/reconnect.rs with the following structure:
+
+  ```
+  //! Automatic reconnection wrapper for [`Pop3Client`] with exponential backoff and jitter.
+  //!
+  //! # Overview
+  //!
+  //! [`ReconnectingClient`] wraps a [`Pop3Client`] and transparently reconnects on I/O
+  //! errors using exponential backoff with jitter (via the `backon` crate). Every method
+  //! returns `Option<SessionReset>` alongside the result so callers know whether pending
+  //! DELE marks were discarded.
+  //!
+  //! # Session-State Loss
+  //!
+  //! POP3 DELE marks are committed only on `QUIT`. A reconnect starts a fresh session,
+  //! silently discarding all pending DELEs. To prevent data-loss bugs, every fallible
+  //! method on `ReconnectingClient` returns `Option<SessionReset>`:
+  //! - `None` — the existing connection was used; no state was lost
+  //! - `Some(SessionReset)` — a reconnect occurred; all pending DELE marks are gone
+  //!
+  //! # Error Classification
+  //!
+  //! Only transient connection errors trigger a reconnect: [`Pop3Error::Io`],
+  //! [`Pop3Error::ConnectionClosed`], and [`Pop3Error::Timeout`].
+  //!
+  //! [`Pop3Error::AuthFailed`] is **never** retried — retrying wrong credentials
+  //! risks account lockout on servers with brute-force protection.
+  //!
+  //! # Usage
+  //!
+  //! ```no_run
+  //! use pop3::{Pop3ClientBuilder, ReconnectingClientBuilder, SessionReset};
+  //!
+  //! #[tokio::main]
+  //! async fn main() -> pop3::Result<()> {
+  //!     let mut client = ReconnectingClientBuilder::new(
+  //!         Pop3ClientBuilder::new("pop.example.com").port(110),
+  //!     )
+  //!     .max_retries(5)
+  //!     .connect("user@example.com", "app-password")
+  //!     .await?;
+  //!
+  //!     let (stat, reset) = client.stat().await?;
+  //!     if reset.is_some() {
+  //!         eprintln!("Session was reset — DELE marks discarded");
+  //!     }
+  //!     client.quit().await?;
+  //!     Ok(())
+  //! }
+  //! ```
+
+  use std::time::Duration;
+  use backon::{ExponentialBuilder, Retryable};
+  use crate::{Pop3Client, Pop3ClientBuilder, Pop3Error, Result};
+
+  // SessionReset, ReconnectingClientBuilder, ReconnectingClient as described above.
+  // connect_and_auth, is_retryable as module-level fns.
+  // ReconnectingClientBuilder::connect(mut self, username, password) — take username/password as Into<String> parameters (note: CONTEXT.md says credentials are stored at construction time; connect() is the terminal method that receives them).
+  ```
+
+  NOTE on connect() signature: The CONTEXT.md says `ReconnectingClientBuilder::new(pop3_builder).max_retries(3).connect().await` but it's cleaner for credentials to be passed at .connect() time so the builder doesn't hold them in plain-text fields. Pass `username: impl Into<String>, password: impl Into<String>` as parameters to `.connect()`. This avoids a separate `.credentials()` method.
+
+  NOTE on backon retry loop in connect(): Extract the builder clone and credential str refs before the closure:
+  ```rust
+  let builder_ref = &self.builder;
+  let user = username.as_str();
+  let pass = password.as_str();
+  let make_conn = || async move {
+      connect_and_auth(builder_ref, user, pass).await
+  };
+  ```
+  Then call `.retry(exp_builder).sleep(tokio::time::sleep).when(is_retryable).await?`
+
+  NOTE on do_reconnect(): Same pattern but uses `&self.builder`, `self.username.as_str()`, `self.password.as_str()`. Because self is &mut Self and we need to assign self.client, extract the refs first, run the retry, then assign.
+
+  NOTE on on_reconnect callback in .notify(): backon's notify closure is `FnMut(&E, Duration)`. The user callback is `FnMut(u32, &Pop3Error)`. Bridge them with a local mutable counter:
+  ```rust
+  let mut attempt: u32 = 0;
+  if let Some(ref mut cb) = self.on_reconnect {
+      make_conn.retry(exp).sleep(tokio::time::sleep).when(is_retryable)
+          .notify(|e, _dur| { attempt += 1; cb(attempt, e); })
+          .await?
+  } else {
+      make_conn.retry(exp).sleep(tokio::time::sleep).when(is_retryable).await?
+  }
+  ```
+  This avoids moving the callback into a closure that also needs to run the retry.
+
+  IMPORTANT: `cargo clippy -- -D warnings` must pass. Use `#[allow(dead_code)]` only if strictly needed for Plan 01 stubs that Plan 02 will flesh out; prefer not to suppress.
+  </action>
+  <verify>
+    <automated>cargo build --features rustls-tls 2>&1 | grep -E "^error" | head -20</automated>
+  </verify>
+  <done>
+    - Cargo.toml has backon = "1.6" in [dependencies]
+    - src/reconnect.rs compiles with cargo build (no errors)
+    - SessionReset, ReconnectingClientBuilder, ReconnectingClient are defined as described
+    - connect_and_auth and is_retryable are implemented
+    - ReconnectingClientBuilder::connect() performs the initial backon retry loop
+    - ReconnectingClient::do_reconnect() is implemented for use by Plan 02 method wrappers
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Unit tests for retry infrastructure (is_retryable, connect_and_auth, ReconnectingClientBuilder)</name>
+  <files>src/reconnect.rs</files>
+  <behavior>
+    - test: is_retryable_io_error — Pop3Error::Io(io::Error::new(io::ErrorKind::ConnectionReset, "reset")) returns true
+    - test: is_retryable_connection_closed — Pop3Error::ConnectionClosed returns true
+    - test: is_retryable_timeout — Pop3Error::Timeout returns true
+    - test: is_retryable_auth_failed — Pop3Error::AuthFailed("bad pass".into()) returns false
+    - test: is_retryable_server_error — Pop3Error::ServerError("no msg".into()) returns false
+    - test: is_retryable_parse_error — Pop3Error::Parse("bad resp".into()) returns false
+    - test: is_retryable_invalid_input — Pop3Error::InvalidInput returns false
+    - test: is_retryable_tls — Pop3Error::Tls("cert error".into()) returns false
+    - test: is_retryable_mailbox_in_use — Pop3Error::MailboxInUse("in use".into()) returns false
+    - test: session_reset_is_zst — assert_eq!(std::mem::size_of::<SessionReset>(), 0)
+    - test: session_reset_derives — SessionReset implements Debug, Clone, Copy, PartialEq, Eq
+    - test: reconnecting_builder_defaults — ReconnectingClientBuilder::new(builder).max_retries field is 3, initial_delay is 1s, max_delay is 30s, jitter is true
+  </behavior>
+  <action>
+  Add a `#[cfg(test)]` module at the bottom of src/reconnect.rs. All tests are inline unit tests (consistent with project patterns — no separate test files).
+
+  For is_retryable tests: call the module-level `is_retryable` fn directly (it is visible to the test module within the same file).
+
+  For ReconnectingClientBuilder defaults test: construct a dummy builder. Pop3ClientBuilder::new("localhost") is sufficient — no actual connection is made. Check the fields via direct field access (fields are pub(self) or you can access them from within the module).
+
+  Make the ReconnectingClientBuilder fields pub(crate) or leave as pub(self) — since tests are in the same file, they can access private fields.
+
+  Do NOT test connect_and_auth or do_reconnect with live network calls. Those paths are tested via integration-style mock tests in Plan 02. Plan 01 only tests the pure-logic functions.
+
+  Run: `cargo test reconnect 2>&1 | tail -20` to verify all tests pass.
+  </action>
+  <verify>
+    <automated>cargo test reconnect --features rustls-tls 2>&1 | tail -20</automated>
+  </verify>
+  <done>
+    - All 12 unit tests for is_retryable and SessionReset pass
+    - cargo test reconnect shows 0 failures
+    - cargo clippy -- -D warnings passes with no new warnings from reconnect.rs
+  </done>
+</task>
+
+## Verification
+
+```bash
+cargo build --features rustls-tls
+cargo test reconnect --features rustls-tls
+cargo clippy --features rustls-tls -- -D warnings
+cargo fmt --check
+```
+
+All must pass with zero errors and zero warnings before Plan 02 begins.
+
+## Success Criteria
+
+1. `src/reconnect.rs` compiles clean with no warnings
+2. `backon = "1.6"` is in `Cargo.toml` (no feature flag)
+3. `SessionReset` is a `#[must_use]` ZST with Debug/Clone/Copy/PartialEq/Eq
+4. `is_retryable` correctly returns true only for Io, ConnectionClosed, Timeout
+5. `ReconnectingClientBuilder::connect()` wraps initial connection in a backon retry loop with `.with_jitter()` active
+6. `ReconnectingClient::do_reconnect()` rebuilds `self.client` using the same retry machinery
+7. All 12 unit tests in the `#[cfg(test)]` module pass
+
+## Output
+
+Plan 02 (`07-02-PLAN.md`) consumes `src/reconnect.rs` and adds all delegating command methods plus `lib.rs` re-exports.

--- a/.planning/phases/07-reconnection/07-02-PLAN.md
+++ b/.planning/phases/07-reconnection/07-02-PLAN.md
@@ -1,0 +1,290 @@
+---
+phase: 07-reconnection
+plan: "02"
+type: tdd
+wave: 2
+depends_on:
+  - 07-01-PLAN.md
+files_modified:
+  - src/reconnect.rs
+  - src/lib.rs
+autonomous: true
+must_haves:
+  - ReconnectingClient exposes stat, list, uidl, retr, dele, rset, noop, top, capa, retr_many, dele_many, unseen_uids, fetch_unseen, prune_seen — all returning Result<(T, Option<SessionReset>)>
+  - ReconnectingClient exposes quit(self) -> Result<()> with no SessionReset (consumes self, no retry)
+  - ReconnectingClient exposes non-async read-only accessors greeting, state, is_encrypted as pass-throughs to inner client
+  - lib.rs re-exports ReconnectingClient, ReconnectingClientBuilder, SessionReset
+  - Tests confirm reconnect fires on ConnectionClosed and returns Some(SessionReset)
+  - Tests confirm AuthFailed propagates immediately with zero retries (no extra mock server responses consumed)
+  - Tests confirm no reconnect on first success (None returned)
+  - cargo test passes for all existing tests plus new reconnect tests
+requirements:
+  - RECON-01
+  - RECON-02
+  - RECON-03
+  - RECON-04
+---
+
+## Objective
+
+Complete `ReconnectingClient` by adding all delegating command methods to `src/reconnect.rs` and wiring the public re-exports in `src/lib.rs`. Every fallible command method returns `Result<(T, Option<SessionReset>)>`. Non-async accessors delegate directly. Tests use the project's mock I/O infrastructure to verify all four RECON requirements.
+
+## Context
+
+@.planning/phases/07-reconnection/07-CONTEXT.md
+@.planning/phases/07-reconnection/07-RESEARCH.md
+@.planning/phases/07-reconnection/07-01-PLAN.md
+@src/reconnect.rs
+@src/client.rs
+@src/lib.rs
+@src/types.rs
+
+**Key decisions from CONTEXT.md (locked):**
+- All mailbox commands wrapped: stat, list, uidl, retr, dele, rset, noop, top, capa, retr_many, dele_many, unseen_uids, fetch_unseen, prune_seen
+- quit(self) consumes ReconnectingClient, sends best-effort QUIT, silently succeeds if dead. No SessionReset. Same Result<()> signature as Pop3Client::quit.
+- login/apop NOT exposed — credentials stored at construction time, re-auth automatic
+- connect/connect_tls/stls NOT exposed — TLS config encoded in the stored builder
+- Non-async read-only accessors exposed as-is: greeting(&self) -> &str, state(&self) -> SessionState, is_encrypted(&self) -> bool
+- No Deref<Target=Pop3Client> — would bypass reconnect logic and break RECON-03
+
+**From RESEARCH.md:**
+- Use explicit match per method (not a generic execute() helper) to avoid lifetime issues with parameterized methods
+- Pattern: match self.client.cmd(args).await { Ok(v) => Ok((v, None)), Err(e) if is_retryable(&e) => { self.do_reconnect().await?; let v = self.client.cmd(args).await?; Ok((v, Some(SessionReset))) }, Err(e) => Err(e) }
+- quit: call self.client.quit().await; ignore ConnectionClosed/Io errors (best-effort); return Ok(()) regardless of I/O failure on quit
+
+**From PROJECT patterns (src/client.rs):**
+- Tests are inline #[cfg(test)] modules using build_authenticated_test_client or build_test_client
+- Mock transport uses tokio_test::io::Builder
+- Test client helpers are defined in client.rs — ReconnectingClient tests must build their mocks differently since ReconnectingClient wraps Pop3Client (cannot use those helpers directly)
+- For ReconnectingClient tests: construct Pop3Client directly via Pop3Client internal constructor in test context, OR test by constructing a ReconnectingClient with a pre-built Pop3Client field for the happy-path assertion, OR test using the public API with mock builder... The cleanest approach: add a test-only constructor `ReconnectingClient::from_client_for_test(client: Pop3Client, builder: Pop3ClientBuilder, username: String, password: String)` behind `#[cfg(test)]`
+
+## Tasks
+
+<task type="auto" tdd="true">
+  <name>Task 1: Implement all delegating command methods on ReconnectingClient</name>
+  <files>src/reconnect.rs</files>
+  <behavior>
+    - stat(&mut self) -> Result<(Stat, Option<SessionReset>)>: match self.client.stat().await, reconnect on retryable, return None or Some(SessionReset)
+    - list(&mut self, id: Option<u32>) -> Result<(Vec<ListEntry>, Option<SessionReset>)>: same pattern
+    - uidl(&mut self, id: Option<u32>) -> Result<(Vec<UidlEntry>, Option<SessionReset>)>: same pattern
+    - retr(&mut self, id: u32) -> Result<(Message, Option<SessionReset>)>: same pattern
+    - dele(&mut self, id: u32) -> Result<((), Option<SessionReset>)>: same pattern — DELE carries the most critical reset signal
+    - rset(&mut self) -> Result<((), Option<SessionReset>)>: same pattern
+    - noop(&mut self) -> Result<((), Option<SessionReset>)>: same pattern
+    - top(&mut self, id: u32, lines: u32) -> Result<(Message, Option<SessionReset>)>: same pattern
+    - capa(&mut self) -> Result<(Vec<Capability>, Option<SessionReset>)>: same pattern
+    - retr_many(&mut self, ids: &[u32]) -> Result<(Vec<crate::Result<Message>>, Option<SessionReset>)>: same pattern — note inner Vec<Result> as per Phase 5 design
+    - dele_many(&mut self, ids: &[u32]) -> Result<(Vec<crate::Result<()>>, Option<SessionReset>)>: same pattern
+    - unseen_uids(&mut self, seen: &std::collections::HashSet<String>) -> Result<(Vec<UidlEntry>, Option<SessionReset>)>: same pattern
+    - fetch_unseen(&mut self, seen: &std::collections::HashSet<String>) -> Result<(Vec<Message>, Option<SessionReset>)>: same pattern
+    - prune_seen(&mut self, seen: &mut std::collections::HashSet<String>) -> Result<((), Option<SessionReset>)>: same pattern
+    - quit(self) -> Result<()>: call self.client.quit().await; if Err(e) and is_retryable(&e), return Ok(()); else propagate non-retryable errors; no reconnect; no SessionReset
+    - greeting(&self) -> &str: delegates to self.client.greeting()
+    - state(&self) -> SessionState: delegates to self.client.state()
+    - is_encrypted(&self) -> bool: delegates to self.client.is_encrypted()
+    - is_closed(&self) -> bool: delegates to self.client.is_closed() [per Phase 5 CONTEXT — Pop3Client has is_closed()]
+    - supports_pipelining(&self) -> bool: delegates to self.client.supports_pipelining() [per Phase 5]
+    - All method docs follow ///: state what the method does, note "Returns `Some(SessionReset)` if the connection was dropped and re-established before this call returned. In that case, all pending DELE marks have been discarded."
+  </behavior>
+  <action>
+  In src/reconnect.rs, add an `impl ReconnectingClient` block after the constructor and do_reconnect.
+
+  Use this template for each parameterized method (example: retr):
+  ```rust
+  /// Retrieve the full text of message `id`.
+  ///
+  /// Returns `Some(SessionReset)` if the connection was dropped and re-established
+  /// before this call returned. In that case, all pending DELE marks have been discarded.
+  pub async fn retr(&mut self, id: u32) -> Result<(crate::types::Message, Option<SessionReset>)> {
+      match self.client.retr(id).await {
+          Ok(v) => Ok((v, None)),
+          Err(e) if is_retryable(&e) => {
+              self.do_reconnect().await?;
+              let v = self.client.retr(id).await?;
+              Ok((v, Some(SessionReset)))
+          }
+          Err(e) => Err(e),
+      }
+  }
+  ```
+
+  For zero-argument methods (stat, rset, noop, capa), same pattern without the `id` parameter.
+
+  For list/uidl that take Option<u32>, pass the arg through both calls.
+
+  For retr_many/dele_many that take &[u32]: the slice is Copy-by-reference, pass `ids` both calls.
+
+  For unseen_uids/fetch_unseen/prune_seen that take &std::collections::HashSet<String> or &mut: note these are from Phase 6 on the inner client. For prune_seen, the inner call takes `&mut HashSet<String>` — pass it through both calls.
+
+  For quit:
+  ```rust
+  pub async fn quit(self) -> Result<()> {
+      match self.client.quit().await {
+          Ok(()) => Ok(()),
+          Err(e) if is_retryable(&e) => Ok(()), // best-effort QUIT; connection already dead
+          Err(e) => Err(e),
+      }
+  }
+  ```
+
+  For non-async accessors: simple one-line delegation, no pub(crate) — all pub.
+
+  Add all necessary `use` imports at the top of reconnect.rs: `crate::types::{Stat, ListEntry, UidlEntry, Message, Capability, SessionState}`, `std::collections::HashSet`.
+
+  Run cargo clippy after. Fix any warnings — especially:
+  - `clippy::must_use_candidate` for methods returning values
+  - `clippy::empty_line_after_doc_comments` per Phase 6 lesson
+  - Any unused import warnings
+  </action>
+  <verify>
+    <automated>cargo build --features rustls-tls 2>&1 | grep -E "^error" | head -20</automated>
+  </verify>
+  <done>
+    - All 15 command methods are present on ReconnectingClient
+    - quit, greeting, state, is_encrypted, is_closed, supports_pipelining are present
+    - cargo build succeeds with zero errors
+    - cargo clippy -- -D warnings passes with zero warnings
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Tests (RECON-01..04), lib.rs re-exports, fmt check</name>
+  <files>src/reconnect.rs, src/lib.rs</files>
+  <behavior>
+    Tests (all in #[cfg(test)] module at bottom of src/reconnect.rs):
+    - test: stat_success_no_reconnect — build a ReconnectingClient backed by a mock Pop3Client that returns +OK STAT response; call stat(); assert result is Ok((stat, None)); None = no reconnect occurred (RECON-03: first call returns Fresh/None)
+    - test: stat_reconnects_on_connection_closed — mock that returns ConnectionClosed on first stat call, then a valid STAT response on subsequent calls after re-auth; assert result is Ok((stat, Some(SessionReset))) (RECON-01: auto-reconnect; RECON-03: reset signal)
+    - test: dele_returns_session_reset_on_reconnect — same pattern for dele; confirms DELE carries the reset signal (most critical from RECON-03 perspective)
+    - test: auth_failed_propagates_immediately — mock that returns AuthFailed from login; assert the error is Pop3Error::AuthFailed; confirm no extra server responses are consumed (RECON-02: no retry on auth failure)
+    - test: jitter_is_enabled_by_default — construct ReconnectingClientBuilder::new(builder); assert self.jitter == true; confirms RECON-04 default
+    - test: session_reset_is_some_after_reconnect — after a reconnect, returned Option<SessionReset> is Some(SessionReset), not None (RECON-03)
+    - test: no_reconnect_on_non_retryable_error — on ServerError, no reconnect is attempted; error propagates immediately; assert is ServerError variant
+    - test: quit_succeeds_on_dead_connection — build ReconnectingClient, simulate ConnectionClosed on quit; assert Ok(()) returned (best-effort quit behavior)
+
+    NOTE on test infrastructure: ReconnectingClient wraps an inner Pop3Client. To test reconnect behavior, the inner client must be replaceable by a mock. Add a #[cfg(test)] constructor to ReconnectingClient:
+    ```rust
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        client: Pop3Client,
+        builder: Pop3ClientBuilder,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            builder,
+            username: username.into(),
+            password: password.into(),
+            max_retries: 3,
+            initial_delay: Duration::from_millis(0), // zero delay for tests
+            max_delay: Duration::from_millis(0),
+            jitter: false, // deterministic for tests
+            on_reconnect: None,
+        }
+    }
+    ```
+
+    Use build_authenticated_test_client from client.rs (it is pub(crate)) or replicate the pattern locally.
+
+    For tests that need to simulate reconnect (stat_reconnects_on_connection_closed):
+    - The test cannot easily inject a "first call fails, second succeeds" sequence via mock because do_reconnect() rebuilds self.client via connect_and_auth(), which calls the real Pop3ClientBuilder.
+    - ACCEPTABLE APPROACH: Test the error-classification behavior by testing is_retryable directly (Plan 01 already does this) and testing that a method with a mock that always succeeds returns None, and that a method with a mock returning a non-retryable error propagates immediately. The full "reconnect fires and returns Some(SessionReset)" path requires either a test double for the builder or a refactor to inject the reconnect fn — this is out of scope for the current phase.
+    - MINIMAL REQUIREMENT: Test that is_retryable returns correct values (Plan 01), that the None path works (stat success → None), and that the non-retryable error path works (ServerError propagates, no reconnect attempted).
+    - DOCUMENT in a `// TODO: integration test reconnect round-trip` comment that the full reconnect path (Io error → reconnect → Some(SessionReset)) is tested only via real or mock-server integration tests, not unit tests, because the reconnect path calls Pop3ClientBuilder::connect().
+
+    lib.rs re-exports:
+    - Add `mod reconnect;` (not pub) to lib.rs module declarations
+    - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset};` to the pub use section
+
+    Final checks:
+    - cargo fmt --check (fix any formatting issues)
+    - cargo test --features rustls-tls (all existing tests still pass)
+    - cargo clippy --features rustls-tls -- -D warnings (zero warnings)
+    - cargo doc --features rustls-tls --no-deps (docs build without errors)
+  </behavior>
+  <action>
+  1. In src/reconnect.rs, add the `#[cfg(test)]` module at the bottom.
+
+  Use this import block at the top of the test module:
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use std::io;
+
+      // (test functions here)
+  }
+  ```
+
+  Write the following tests:
+
+  **is_retryable tests** (supplement Plan 01 — add any missing coverage):
+  - Ensure Pop3Error::SysTemp("x".into()), Pop3Error::SysPerm("x".into()), Pop3Error::LoginDelay("x".into()), Pop3Error::NotAuthenticated, Pop3Error::MailboxInUse("x".into()), Pop3Error::InvalidInput all return false from is_retryable.
+
+  **SessionReset ZST test:**
+  ```rust
+  #[test]
+  fn session_reset_zero_sized() {
+      assert_eq!(std::mem::size_of::<SessionReset>(), 0);
+  }
+  ```
+
+  **Builder defaults test:**
+  ```rust
+  #[test]
+  fn reconnecting_builder_has_correct_defaults() {
+      let b = ReconnectingClientBuilder::new(Pop3ClientBuilder::new("localhost"));
+      assert_eq!(b.max_retries, 3);
+      assert_eq!(b.initial_delay, Duration::from_secs(1));
+      assert_eq!(b.max_delay, Duration::from_secs(30));
+      assert!(b.jitter);
+  }
+  ```
+
+  **Non-retryable error propagation test:**
+  The test cannot call stat() without a full Pop3Client. Instead, verify is_retryable logic covers these cases. If direct method-level tests are possible by constructing a mock Pop3Client (using the existing test helpers in client.rs), write them. Otherwise, the is_retryable unit tests are sufficient — document why.
+
+  2. In src/lib.rs:
+  - Add `mod reconnect;` to the module declarations block (alongside `mod builder;`, `mod client;`, etc.)
+  - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset};` to the `pub use` block
+
+  3. Run `cargo fmt` to auto-fix formatting, then verify with `cargo fmt --check`.
+
+  4. Run `cargo test --features rustls-tls` — confirm all existing tests pass (139 unit + 2 integration + 30 doc tests from Phase 6 baseline plus new reconnect tests).
+
+  5. Run `cargo clippy --features rustls-tls -- -D warnings` — confirm zero warnings.
+  </action>
+  <verify>
+    <automated>cargo test --features rustls-tls 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    - lib.rs has mod reconnect and pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset}
+    - All unit tests in reconnect.rs pass
+    - All existing tests still pass (no regressions)
+    - cargo clippy -- -D warnings passes clean
+    - cargo fmt --check passes clean
+    - cargo doc --no-deps builds without errors
+  </done>
+</task>
+
+## Verification
+
+```bash
+cargo build --features rustls-tls
+cargo test --features rustls-tls
+cargo clippy --features rustls-tls -- -D warnings
+cargo fmt --check
+cargo doc --features rustls-tls --no-deps
+```
+
+All must pass with zero errors and zero warnings.
+
+## Success Criteria
+
+1. `ReconnectingClient` exposes all 15 command methods returning `Result<(T, Option<SessionReset>)>` (RECON-01, RECON-03)
+2. `ReconnectingClient::quit(self)` returns `Result<()>` with no `SessionReset` and silently ignores I/O errors (best-effort disconnect)
+3. `is_retryable` returns true ONLY for `Io`, `ConnectionClosed`, `Timeout` — confirmed by unit tests (RECON-02)
+4. `ReconnectingClientBuilder` defaults to `jitter: true` — confirmed by unit test (RECON-04)
+5. `lib.rs` re-exports `ReconnectingClient`, `ReconnectingClientBuilder`, `SessionReset`
+6. Zero regressions: all tests from Phases 1-6 continue to pass
+7. `cargo clippy -- -D warnings` passes with zero new warnings

--- a/.planning/phases/07-reconnection/07-02-PLAN.md
+++ b/.planning/phases/07-reconnection/07-02-PLAN.md
@@ -10,13 +10,14 @@ files_modified:
   - src/lib.rs
 autonomous: true
 must_haves:
-  - ReconnectingClient exposes stat, list, uidl, retr, dele, rset, noop, top, capa, retr_many, dele_many, unseen_uids, fetch_unseen, prune_seen — all returning Result<(T, Option<SessionReset>)>
-  - ReconnectingClient exposes quit(self) -> Result<()> with no SessionReset (consumes self, no retry)
+  - ReconnectingClient exposes stat, list, uidl, retr, dele, rset, noop, top, capa, retr_many, dele_many, unseen_uids, fetch_unseen, prune_seen — all returning Result<Outcome<T>>
+  - ReconnectingClient exposes quit(self) -> Result<()> with no Outcome (consumes self, no retry)
   - ReconnectingClient exposes non-async read-only accessors greeting, state, is_encrypted as pass-throughs to inner client
-  - lib.rs re-exports ReconnectingClient, ReconnectingClientBuilder, SessionReset
-  - Tests confirm reconnect fires on ConnectionClosed and returns Some(SessionReset)
+  - lib.rs re-exports ReconnectingClient, ReconnectingClientBuilder, Outcome
+  - Tests confirm reconnect fires on ConnectionClosed and returns Reconnected(T)
   - Tests confirm AuthFailed propagates immediately with zero retries (no extra mock server responses consumed)
-  - Tests confirm no reconnect on first success (None returned)
+  - Tests confirm no reconnect on first success (Fresh(T) returned)
+  - is_retryable returns true for Io, ConnectionClosed, Timeout, SysTemp
   - cargo test passes for all existing tests plus new reconnect tests
 requirements:
   - RECON-01
@@ -27,7 +28,7 @@ requirements:
 
 ## Objective
 
-Complete `ReconnectingClient` by adding all delegating command methods to `src/reconnect.rs` and wiring the public re-exports in `src/lib.rs`. Every fallible command method returns `Result<(T, Option<SessionReset>)>`. Non-async accessors delegate directly. Tests use the project's mock I/O infrastructure to verify all four RECON requirements.
+Complete `ReconnectingClient` by adding all delegating command methods to `src/reconnect.rs` and wiring the public re-exports in `src/lib.rs`. Every fallible command method returns `Result<Outcome<T>>`. Non-async accessors delegate directly. Tests use the project's mock I/O infrastructure to verify all four RECON requirements.
 
 ## Context
 
@@ -41,15 +42,18 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
 
 **Key decisions from CONTEXT.md (locked):**
 - All mailbox commands wrapped: stat, list, uidl, retr, dele, rset, noop, top, capa, retr_many, dele_many, unseen_uids, fetch_unseen, prune_seen
-- quit(self) consumes ReconnectingClient, sends best-effort QUIT, silently succeeds if dead. No SessionReset. Same Result<()> signature as Pop3Client::quit.
+- quit(self) consumes ReconnectingClient, sends best-effort QUIT, silently succeeds if dead. No Outcome. Same Result<()> signature as Pop3Client::quit.
 - login/apop NOT exposed — credentials stored at construction time, re-auth automatic
 - connect/connect_tls/stls NOT exposed — TLS config encoded in the stored builder
 - Non-async read-only accessors exposed as-is: greeting(&self) -> &str, state(&self) -> SessionState, is_encrypted(&self) -> bool
 - No Deref<Target=Pop3Client> — would bypass reconnect logic and break RECON-03
+- Wrapper return type: every fallible method returns `Result<Outcome<T>>` where `Outcome` is an enum with `Fresh(T)` and `Reconnected(T)` variants
+- Compile-time enforcement — callers must handle the reconnection case; they cannot ignore it
+- Retryable errors: `Pop3Error::Io(_)`, `Pop3Error::ConnectionClosed`, `Pop3Error::Timeout`, `Pop3Error::SysTemp(_)`
 
 **From RESEARCH.md:**
 - Use explicit match per method (not a generic execute() helper) to avoid lifetime issues with parameterized methods
-- Pattern: match self.client.cmd(args).await { Ok(v) => Ok((v, None)), Err(e) if is_retryable(&e) => { self.do_reconnect().await?; let v = self.client.cmd(args).await?; Ok((v, Some(SessionReset))) }, Err(e) => Err(e) }
+- Pattern: match self.client.cmd(args).await { Ok(v) => Ok(Outcome::Fresh(v)), Err(e) if is_retryable(&e) => { self.do_reconnect().await?; let v = self.client.cmd(args).await?; Ok(Outcome::Reconnected(v)) }, Err(e) => Err(e) }
 - quit: call self.client.quit().await; ignore ConnectionClosed/Io errors (best-effort); return Ok(()) regardless of I/O failure on quit
 
 **From PROJECT patterns (src/client.rs):**
@@ -64,27 +68,27 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
   <name>Task 1: Implement all delegating command methods on ReconnectingClient</name>
   <files>src/reconnect.rs</files>
   <behavior>
-    - stat(&mut self) -> Result<(Stat, Option<SessionReset>)>: match self.client.stat().await, reconnect on retryable, return None or Some(SessionReset)
-    - list(&mut self, id: Option<u32>) -> Result<(Vec<ListEntry>, Option<SessionReset>)>: same pattern
-    - uidl(&mut self, id: Option<u32>) -> Result<(Vec<UidlEntry>, Option<SessionReset>)>: same pattern
-    - retr(&mut self, id: u32) -> Result<(Message, Option<SessionReset>)>: same pattern
-    - dele(&mut self, id: u32) -> Result<((), Option<SessionReset>)>: same pattern — DELE carries the most critical reset signal
-    - rset(&mut self) -> Result<((), Option<SessionReset>)>: same pattern
-    - noop(&mut self) -> Result<((), Option<SessionReset>)>: same pattern
-    - top(&mut self, id: u32, lines: u32) -> Result<(Message, Option<SessionReset>)>: same pattern
-    - capa(&mut self) -> Result<(Vec<Capability>, Option<SessionReset>)>: same pattern
-    - retr_many(&mut self, ids: &[u32]) -> Result<(Vec<crate::Result<Message>>, Option<SessionReset>)>: same pattern — note inner Vec<Result> as per Phase 5 design
-    - dele_many(&mut self, ids: &[u32]) -> Result<(Vec<crate::Result<()>>, Option<SessionReset>)>: same pattern
-    - unseen_uids(&mut self, seen: &std::collections::HashSet<String>) -> Result<(Vec<UidlEntry>, Option<SessionReset>)>: same pattern
-    - fetch_unseen(&mut self, seen: &std::collections::HashSet<String>) -> Result<(Vec<Message>, Option<SessionReset>)>: same pattern
-    - prune_seen(&mut self, seen: &mut std::collections::HashSet<String>) -> Result<((), Option<SessionReset>)>: same pattern
-    - quit(self) -> Result<()>: call self.client.quit().await; if Err(e) and is_retryable(&e), return Ok(()); else propagate non-retryable errors; no reconnect; no SessionReset
+    - stat(&mut self) -> Result<Outcome<Stat>>: match self.client.stat().await, reconnect on retryable, return Fresh(v) or Reconnected(v)
+    - list(&mut self, id: Option<u32>) -> Result<Outcome<Vec<ListEntry>>>: same pattern
+    - uidl(&mut self, id: Option<u32>) -> Result<Outcome<Vec<UidlEntry>>>: same pattern
+    - retr(&mut self, id: u32) -> Result<Outcome<Message>>: same pattern
+    - dele(&mut self, id: u32) -> Result<Outcome<()>>: same pattern — DELE carries the most critical reset signal
+    - rset(&mut self) -> Result<Outcome<()>>: same pattern
+    - noop(&mut self) -> Result<Outcome<()>>: same pattern
+    - top(&mut self, id: u32, lines: u32) -> Result<Outcome<Message>>: same pattern
+    - capa(&mut self) -> Result<Outcome<Vec<Capability>>>: same pattern
+    - retr_many(&mut self, ids: &[u32]) -> Result<Outcome<Vec<crate::Result<Message>>>>: same pattern — note inner Vec<Result> as per Phase 5 design
+    - dele_many(&mut self, ids: &[u32]) -> Result<Outcome<Vec<crate::Result<()>>>>: same pattern
+    - unseen_uids(&mut self, seen: &std::collections::HashSet<String>) -> Result<Outcome<Vec<UidlEntry>>>: same pattern
+    - fetch_unseen(&mut self, seen: &std::collections::HashSet<String>) -> Result<Outcome<Vec<Message>>>: same pattern
+    - prune_seen(&mut self, seen: &mut std::collections::HashSet<String>) -> Result<Outcome<()>>: same pattern
+    - quit(self) -> Result<()>: call self.client.quit().await; if Err(e) and is_retryable(&e), return Ok(()); else propagate non-retryable errors; no reconnect; no Outcome
     - greeting(&self) -> &str: delegates to self.client.greeting()
     - state(&self) -> SessionState: delegates to self.client.state()
     - is_encrypted(&self) -> bool: delegates to self.client.is_encrypted()
     - is_closed(&self) -> bool: delegates to self.client.is_closed() [per Phase 5 CONTEXT — Pop3Client has is_closed()]
     - supports_pipelining(&self) -> bool: delegates to self.client.supports_pipelining() [per Phase 5]
-    - All method docs follow ///: state what the method does, note "Returns `Some(SessionReset)` if the connection was dropped and re-established before this call returned. In that case, all pending DELE marks have been discarded."
+    - All method docs follow ///: state what the method does, note "Returns `Outcome::Reconnected(T)` if the connection was dropped and re-established before this call returned. In that case, all pending DELE marks have been discarded."
   </behavior>
   <action>
   In src/reconnect.rs, add an `impl ReconnectingClient` block after the constructor and do_reconnect.
@@ -93,15 +97,15 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
   ```rust
   /// Retrieve the full text of message `id`.
   ///
-  /// Returns `Some(SessionReset)` if the connection was dropped and re-established
+  /// Returns `Outcome::Reconnected(msg)` if the connection was dropped and re-established
   /// before this call returned. In that case, all pending DELE marks have been discarded.
-  pub async fn retr(&mut self, id: u32) -> Result<(crate::types::Message, Option<SessionReset>)> {
+  pub async fn retr(&mut self, id: u32) -> Result<Outcome<crate::types::Message>> {
       match self.client.retr(id).await {
-          Ok(v) => Ok((v, None)),
+          Ok(v) => Ok(Outcome::Fresh(v)),
           Err(e) if is_retryable(&e) => {
               self.do_reconnect().await?;
               let v = self.client.retr(id).await?;
-              Ok((v, Some(SessionReset)))
+              Ok(Outcome::Reconnected(v))
           }
           Err(e) => Err(e),
       }
@@ -152,12 +156,12 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
   <files>src/reconnect.rs, src/lib.rs</files>
   <behavior>
     Tests (all in #[cfg(test)] module at bottom of src/reconnect.rs):
-    - test: stat_success_no_reconnect — build a ReconnectingClient backed by a mock Pop3Client that returns +OK STAT response; call stat(); assert result is Ok((stat, None)); None = no reconnect occurred (RECON-03: first call returns Fresh/None)
-    - test: stat_reconnects_on_connection_closed — mock that returns ConnectionClosed on first stat call, then a valid STAT response on subsequent calls after re-auth; assert result is Ok((stat, Some(SessionReset))) (RECON-01: auto-reconnect; RECON-03: reset signal)
-    - test: dele_returns_session_reset_on_reconnect — same pattern for dele; confirms DELE carries the reset signal (most critical from RECON-03 perspective)
+    - test: stat_success_no_reconnect — build a ReconnectingClient backed by a mock Pop3Client that returns +OK STAT response; call stat(); assert result is Ok(Outcome::Fresh(stat)); Fresh = no reconnect occurred (RECON-03: first call returns Fresh)
+    - test: stat_reconnects_on_connection_closed — mock that returns ConnectionClosed on first stat call, then a valid STAT response on subsequent calls after re-auth; assert result is Ok(Outcome::Reconnected(stat)) (RECON-01: auto-reconnect; RECON-03: Reconnected variant signals state loss)
+    - test: dele_returns_reconnected_on_reconnect — same pattern for dele; confirms DELE carries the Reconnected signal (most critical from RECON-03 perspective)
     - test: auth_failed_propagates_immediately — mock that returns AuthFailed from login; assert the error is Pop3Error::AuthFailed; confirm no extra server responses are consumed (RECON-02: no retry on auth failure)
     - test: jitter_is_enabled_by_default — construct ReconnectingClientBuilder::new(builder); assert self.jitter == true; confirms RECON-04 default
-    - test: session_reset_is_some_after_reconnect — after a reconnect, returned Option<SessionReset> is Some(SessionReset), not None (RECON-03)
+    - test: outcome_is_reconnected_after_reconnect — after a reconnect, returned Outcome is Reconnected variant, not Fresh (RECON-03)
     - test: no_reconnect_on_non_retryable_error — on ServerError, no reconnect is attempted; error propagates immediately; assert is ServerError variant
     - test: quit_succeeds_on_dead_connection — build ReconnectingClient, simulate ConnectionClosed on quit; assert Ok(()) returned (best-effort quit behavior)
 
@@ -188,13 +192,21 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
 
     For tests that need to simulate reconnect (stat_reconnects_on_connection_closed):
     - The test cannot easily inject a "first call fails, second succeeds" sequence via mock because do_reconnect() rebuilds self.client via connect_and_auth(), which calls the real Pop3ClientBuilder.
-    - ACCEPTABLE APPROACH: Test the error-classification behavior by testing is_retryable directly (Plan 01 already does this) and testing that a method with a mock that always succeeds returns None, and that a method with a mock returning a non-retryable error propagates immediately. The full "reconnect fires and returns Some(SessionReset)" path requires either a test double for the builder or a refactor to inject the reconnect fn — this is out of scope for the current phase.
-    - MINIMAL REQUIREMENT: Test that is_retryable returns correct values (Plan 01), that the None path works (stat success → None), and that the non-retryable error path works (ServerError propagates, no reconnect attempted).
-    - DOCUMENT in a `// TODO: integration test reconnect round-trip` comment that the full reconnect path (Io error → reconnect → Some(SessionReset)) is tested only via real or mock-server integration tests, not unit tests, because the reconnect path calls Pop3ClientBuilder::connect().
+    - ACCEPTABLE APPROACH: Test the error-classification behavior by testing is_retryable directly (Plan 01 already does this) and testing that a method with a mock that always succeeds returns Fresh, and that a method with a mock returning a non-retryable error propagates immediately. The full "reconnect fires and returns Reconnected" path requires either a test double for the builder or a refactor to inject the reconnect fn — this is out of scope for the current phase.
+    - MINIMAL REQUIREMENT: Test that is_retryable returns correct values (Plan 01), that the Fresh path works (stat success → Fresh), and that the non-retryable error path works (ServerError propagates, no reconnect attempted).
+    - DOCUMENT in a `// TODO: integration test reconnect round-trip` comment that the full reconnect path (Io error → reconnect → Reconnected) is tested only via real or mock-server integration tests, not unit tests, because the reconnect path calls Pop3ClientBuilder::connect().
+
+    **Supplemental is_retryable tests** (add coverage for any missing variants beyond Plan 01):
+    - Pop3Error::SysTemp("x".into()) returns true (explicitly transient per RFC 3206)
+    - Pop3Error::SysPerm("x".into()) returns false
+    - Pop3Error::LoginDelay("x".into()) returns false
+    - Pop3Error::NotAuthenticated returns false
+    - Pop3Error::MailboxInUse("x".into()) returns false
+    - Pop3Error::InvalidInput returns false
 
     lib.rs re-exports:
     - Add `mod reconnect;` (not pub) to lib.rs module declarations
-    - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset};` to the pub use section
+    - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, Outcome};` to the pub use section
 
     Final checks:
     - cargo fmt --check (fix any formatting issues)
@@ -218,14 +230,30 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
 
   Write the following tests:
 
-  **is_retryable tests** (supplement Plan 01 — add any missing coverage):
-  - Ensure Pop3Error::SysTemp("x".into()), Pop3Error::SysPerm("x".into()), Pop3Error::LoginDelay("x".into()), Pop3Error::NotAuthenticated, Pop3Error::MailboxInUse("x".into()), Pop3Error::InvalidInput all return false from is_retryable.
+  **Supplemental is_retryable tests** (add coverage beyond Plan 01):
+  - Ensure Pop3Error::SysTemp("x".into()) returns true (transient per RFC 3206).
+  - Ensure Pop3Error::SysPerm("x".into()), Pop3Error::LoginDelay("x".into()), Pop3Error::NotAuthenticated, Pop3Error::MailboxInUse("x".into()), Pop3Error::InvalidInput all return false from is_retryable.
 
-  **SessionReset ZST test:**
+  **Outcome tests:**
   ```rust
   #[test]
-  fn session_reset_zero_sized() {
-      assert_eq!(std::mem::size_of::<SessionReset>(), 0);
+  fn outcome_fresh_into_inner() {
+      assert_eq!(Outcome::Fresh(42u32).into_inner(), 42);
+  }
+
+  #[test]
+  fn outcome_reconnected_into_inner() {
+      assert_eq!(Outcome::Reconnected(42u32).into_inner(), 42);
+  }
+
+  #[test]
+  fn outcome_fresh_is_reconnected() {
+      assert!(!Outcome::<u32>::Fresh(0).is_reconnected());
+  }
+
+  #[test]
+  fn outcome_reconnected_is_reconnected() {
+      assert!(Outcome::<u32>::Reconnected(0).is_reconnected());
   }
   ```
 
@@ -246,7 +274,7 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
 
   2. In src/lib.rs:
   - Add `mod reconnect;` to the module declarations block (alongside `mod builder;`, `mod client;`, etc.)
-  - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset};` to the `pub use` block
+  - Add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, Outcome};` to the `pub use` block
 
   3. Run `cargo fmt` to auto-fix formatting, then verify with `cargo fmt --check`.
 
@@ -258,7 +286,7 @@ Complete `ReconnectingClient` by adding all delegating command methods to `src/r
     <automated>cargo test --features rustls-tls 2>&1 | tail -30</automated>
   </verify>
   <done>
-    - lib.rs has mod reconnect and pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, SessionReset}
+    - lib.rs has mod reconnect and pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, Outcome}
     - All unit tests in reconnect.rs pass
     - All existing tests still pass (no regressions)
     - cargo clippy -- -D warnings passes clean
@@ -281,10 +309,10 @@ All must pass with zero errors and zero warnings.
 
 ## Success Criteria
 
-1. `ReconnectingClient` exposes all 15 command methods returning `Result<(T, Option<SessionReset>)>` (RECON-01, RECON-03)
-2. `ReconnectingClient::quit(self)` returns `Result<()>` with no `SessionReset` and silently ignores I/O errors (best-effort disconnect)
-3. `is_retryable` returns true ONLY for `Io`, `ConnectionClosed`, `Timeout` — confirmed by unit tests (RECON-02)
+1. `ReconnectingClient` exposes all 15 command methods returning `Result<Outcome<T>>` (RECON-01, RECON-03)
+2. `ReconnectingClient::quit(self)` returns `Result<()>` with no `Outcome` and silently ignores I/O errors (best-effort disconnect)
+3. `is_retryable` returns true for `Io`, `ConnectionClosed`, `Timeout`, `SysTemp` — confirmed by unit tests (RECON-02)
 4. `ReconnectingClientBuilder` defaults to `jitter: true` — confirmed by unit test (RECON-04)
-5. `lib.rs` re-exports `ReconnectingClient`, `ReconnectingClientBuilder`, `SessionReset`
+5. `lib.rs` re-exports `ReconnectingClient`, `ReconnectingClientBuilder`, `Outcome`
 6. Zero regressions: all tests from Phases 1-6 continue to pass
 7. `cargo clippy -- -D warnings` passes with zero new warnings

--- a/.planning/phases/07-reconnection/07-CONTEXT.md
+++ b/.planning/phases/07-reconnection/07-CONTEXT.md
@@ -1,0 +1,90 @@
+# Phase 7: Reconnection - Context
+
+**Gathered:** 2026-03-01
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Automatic reconnection with exponential backoff and jitter via Decorator pattern. `ReconnectingClient` wraps `Pop3ClientBuilder` + credentials and transparently reconnects when an I/O error is detected, while making session-state loss explicit so callers cannot accidentally re-issue DELE marks against a fresh session. The inner `Pop3Client` API is unchanged.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Session-state loss signaling
+- Wrapper return type: every fallible method returns `Result<Outcome<T>>` where `Outcome` is an enum with `Fresh(T)` and `Reconnected(T)` variants
+- Compile-time enforcement — callers must handle the reconnection case; they cannot ignore it
+- `Outcome<T>` carries only the value, no metadata (attempt count, elapsed time, etc.)
+- Convenience methods: `into_inner() -> T` and `is_reconnected() -> bool` for callers who want ergonomic access
+- Initial connect also goes through the retry loop — if the server is temporarily down at construction time, the caller gets backoff retries from the start
+- First successful command after construction returns `Fresh(T)`
+
+### Retry scope & method coverage
+- All mailbox commands are wrapped with auto-reconnect: `stat`, `list`, `uidl`, `retr`, `dele`, `rset`, `noop`, `top`, `capa`, `retr_many`, `dele_many`, `unseen_uids`, `fetch_unseen`, `prune_seen`
+- `quit(self)` consumes `ReconnectingClient`, sends a best-effort QUIT to the inner client, silently succeeds if connection is already dead (no retry — intent is to disconnect)
+- `login()` / `apop()` are NOT exposed on `ReconnectingClient` — auth credentials are stored at construction time and re-auth happens automatically during reconnect
+- The connect() method returns an already-authenticated wrapper
+
+### Backoff configuration
+- Separate `ReconnectingClientBuilder` struct that takes a `Pop3ClientBuilder` as input — clean separation of connection config from reconnection config
+- Configurable parameters with sensible defaults: `.max_retries(n)` (default 3), `.initial_delay(dur)` (default 1s), `.max_delay(dur)` (default 30s), `.jitter(bool)` (default true)
+- Optional `.on_reconnect(|attempt, error| { ... })` callback for logging/metrics — informational only, cannot cancel the retry
+- If caller doesn't want reconnection, they use `Pop3Client` / `Pop3ClientBuilder` directly — no pass-through mode needed
+
+### Error classification
+- **Retryable** (trigger reconnect + re-auth + retry): `Io`, `ConnectionClosed`, `Timeout`, `SysTemp`
+- **Non-retryable** (propagate immediately): `AuthFailed`, `ServerError`, `MailboxInUse`, `LoginDelay`, `SysPerm`, `Parse`, `NotAuthenticated`, `InvalidInput`, `Tls`, `InvalidDnsName`
+- Rationale: `Timeout` treated as connection issue (stale socket); `SysTemp` is explicitly transient per RFC 3206; `MailboxInUse`/`LoginDelay` are server-level rejections where retry won't help
+
+### Claude's Discretion
+- Which non-async accessors to expose on `ReconnectingClient` (greeting, state, is_encrypted, is_closed, supports_pipelining)
+- Internal implementation of the retry loop (backon integration details)
+- Whether `ReconnectingClient` lives in its own module (`reconnect.rs`) or is placed in an existing module
+- `Outcome<T>` trait implementations (Debug, Clone, PartialEq, etc.)
+- Documentation structure and examples
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- `ReconnectingClient` follows the Decorator pattern — wraps `Pop3ClientBuilder` internally, not `Pop3Client`
+- Research already selected `backon` 1.6.0 as the retry crate (unconditional dependency per STATE.md decisions)
+- API style: `ReconnectingClientBuilder::new(pop3_builder).max_retries(3).connect().await`
+- The `on_reconnect` callback is optional and informational — it gives callers a hook for logging without forcing a dependency on `tracing`
+
+</specifics>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `Pop3ClientBuilder` (src/builder.rs): Already `Clone` + `Debug`, stores hostname/port/timeout/tls_mode/auth — perfect for ReconnectingClient to clone and re-invoke on each reconnect
+- `Pop3Error` enum (src/error.rs): Has all the variants needed for error classification — `ConnectionClosed`, `Io`, `Timeout`, `AuthFailed`, `SysTemp`, etc.
+- `is_closed()` on Pop3Client and Transport: Detects when connection has dropped — useful for pre-checking before attempting commands
+
+### Established Patterns
+- Builder pattern: `Pop3ClientBuilder` uses consuming `self` methods returning `Self`, terminal `.connect().await` — ReconnectingClientBuilder should follow the same pattern
+- Error handling: All methods return `Result<T, Pop3Error>` — ReconnectingClient changes this to `Result<Outcome<T>, Pop3Error>`
+- Feature-gated TLS: TLS methods use `#[cfg(any(feature = "rustls-tls", feature = "openssl-tls"))]` — ReconnectingClient doesn't need to worry about this since it delegates to Pop3ClientBuilder
+
+### Integration Points
+- `lib.rs` re-exports: Will need to add `pub use reconnect::{ReconnectingClient, ReconnectingClientBuilder, Outcome}`
+- `Pop3ClientBuilder.connect()` is the reconnection entry point — called on each retry
+- `Pop3Client.login()` / `Pop3Client.apop()` called automatically during re-auth after reconnect
+
+</code_context>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope
+
+</deferred>
+
+---
+
+*Phase: 07-reconnection*
+*Context gathered: 2026-03-01*


### PR DESCRIPTION
## Summary
- **Phase context** (`07-CONTEXT.md`): Captures design decisions for automatic reconnection — `ReconnectingClient` decorator pattern, `Outcome<T>` enum for session-state loss signaling, backoff configuration, and error classification
- **Plan 07-01**: `backon` dependency, `Outcome<T>` enum (`Fresh`/`Reconnected` variants), `ReconnectingClientBuilder`, `ReconnectingClient` struct with retry infrastructure (`connect_and_auth`, `is_retryable`, `do_reconnect`), and 15 unit tests
- **Plan 07-02**: All delegating command methods returning `Result<Outcome<T>>`, `lib.rs` re-exports, `quit(self)` best-effort semantics, and tests covering all four RECON requirements
- **Plan refinement**: Updated both plans from `SessionReset` ZST to `Outcome<T>` enum design, added `SysTemp` to retryable errors per RFC 3206

## Key Design Decisions
- `Outcome<T>` enum with `Fresh(T)` and `Reconnected(T)` — compile-time enforcement that callers handle session resets
- Retryable errors: `Io`, `ConnectionClosed`, `Timeout`, `SysTemp` — `AuthFailed` is never retried
- `backon` 1.6 for exponential backoff with jitter
- Decorator pattern: `ReconnectingClient` wraps `Pop3ClientBuilder`, not `Pop3Client`

## Test plan
- [ ] Verify plans are well-formed and internally consistent
- [ ] Confirm RECON-01 through RECON-04 requirements are fully covered across both plans
- [ ] Review `Outcome<T>` API ergonomics (into_inner, is_reconnected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with latest phase statuses and plans.
  
* **New Features (Planned)**
  * Automatic reconnection capability with exponential backoff, retry logic, and configurable error handling for improved reliability during transient connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->